### PR TITLE
Advance card draw logic, non reapeting texts, more texts for cards

### DIFF
--- a/Empathy-Game/Assets/Scripts/CardManager.cs
+++ b/Empathy-Game/Assets/Scripts/CardManager.cs
@@ -21,6 +21,11 @@ public sealed class CardManager : MonoBehaviour
     public List<CardScript> CardsInGame = new List<CardScript>();
     public List<CardScript> UsedCards = new List<CardScript>();
     public GameObject CardPrefab;
+
+    public int ChanceToDrawCoopCard = 50;   
+    public int ChanceToDrawSoloCard = 50;
+    private NonRepeatingTextGetter textGetter = new();
+
     // Start is called before the first frame update
     void Start()
     {
@@ -80,8 +85,7 @@ public sealed class CardManager : MonoBehaviour
         if(playerLabels.Count != 0) //if no labels, fallback to solo card
         {
             var randomLabel = playerLabels[Random.Range(0, playerLabels.Count)];
-            var textList = Constants.CardText.EnumToTextList(randomLabel);
-            var randomText = textList[Random.Range(0, textList.Count)];
+            var randomText = textGetter.NonReapetingTextByLabel(randomLabel);
 
             //coop only revelent fields
             coopCard.isCoopCard = true;
@@ -95,7 +99,7 @@ public sealed class CardManager : MonoBehaviour
     public CardScript InitOrCreateASoloCard(CardScript optinalCardToinit = null)
     {
         CardScript card = optinalCardToinit ?? new CardScript();
-        card.FreeText.text = CardText.GeneralText[UnityEngine.Random.Range(0, CardText.GeneralText.Count)];
+        card.FreeText.text = textGetter.NonReapetingTextGeneral();
 
         //time
         card.time = CardTime.GetRandomTimeEnum();
@@ -108,5 +112,24 @@ public sealed class CardManager : MonoBehaviour
         card.TeamPointsText.text = $"+{card.TeamPoints}";
 
         return card;
+    }
+
+    public CardScript InitARandomCard(CardScript card)
+    {
+        CardScript newCard = card ?? new CardScript();
+
+        int totalChances = ChanceToDrawCoopCard + ChanceToDrawSoloCard;
+        int rndCardChange = Random.Range(0, totalChances);
+
+        if(rndCardChange < ChanceToDrawCoopCard)
+        {
+            InitOrCreateACoopCard(newCard);
+        }
+        else
+        {
+            InitOrCreateASoloCard(newCard);
+        }
+
+        return newCard;
     }
 }

--- a/Empathy-Game/Assets/Scripts/CardSlotsManager.cs
+++ b/Empathy-Game/Assets/Scripts/CardSlotsManager.cs
@@ -60,7 +60,7 @@ public sealed class CardSlotsManager : MonoBehaviour
             if (availableSlot[i] == true)
             {
                 CardScript newCard = Instantiate(CardManager.InstanceCardManager.CardPrefab, Slots[i].position, Quaternion.identity).GetComponent<CardScript>();
-                CardManager.InstanceCardManager.InitOrCreateACoopCard(newCard);
+                CardManager.InstanceCardManager.InitARandomCard(newCard);
 
                 Debug.Log($"New {((newCard.isCoopCard)?("Co-op"):("Solo"))} card was created in slot " + i);
                 availableSlot[i] = false;

--- a/Empathy-Game/Assets/Scripts/Constants.cs
+++ b/Empathy-Game/Assets/Scripts/Constants.cs
@@ -47,13 +47,21 @@ namespace Constants
         {
             "Finish a PR reveiw",
             "Talk to my manager about my salary",
-            "Update my Linked-In profile"
+            "Update my Linked-In profile",
+            "Mentor an intern",
+            "Create technical documentation",
+            "Write reports",
+            "Conduct market research",
+            "Prioritize tasks and create to-do lists",
+            "Research and explore new areas of interest",
+            "Prioritize tasks and create to-do lists"
         };
         public static List<string> DevReqText = new List<string>
         {
             "Get your code review",
             "Complain about a bug",
-            "Create a new feature",
+            "Help to create a new feature",
+            "Ask to assist with implementing a security update"
         };
         public static List<string> ITReqText = new List<string>
         {
@@ -61,23 +69,34 @@ namespace Constants
             "Install a new software",
             "Fix the printer",
             "Fix the computer",
+            "Request assistance in setting up a new software application",
+            "Request a backup of your important files",
+            "Ask for training on using a new software tool"
         };
         public static List<string> PMReqText = new List<string>
         {
             "Meet with a client",
             "Meeting 1:1",
             "Retrospective meeting",
+            "Brainstorming session",
+            "Meet to discuss feature priorities",
+            "Request feedback on your product improvements"
         };
         public static List<string> HRReqText = new List<string>
         {
             "Talk about my vacation",
-            "Talkabout my promotion",
+            "Ask for assistance in administering payroll and benefits",
             "Learn about the company values",
+            "Request input on implementing diversity and inclusion initiatives",
+            "Request assistance in conducting interviews and the hiring process",
+            "Seek guidance in developing and updating HR policies and procedures"
         };
         public static List<string> QAReqText = new List<string>
         {
-            "Test a new feature",
+            "Request a review of your test plans and test cases",
             "Test a new product",
+            "Seek input on continuous improvement of testing processes and methodologies",
+            "Ask for assistance in reporting and tracking software defects"
         };
 
         public static List<string> EnumToTextList(LabelEnum label)

--- a/Empathy-Game/Assets/Scripts/NonRepeatingTextGetter.cs
+++ b/Empathy-Game/Assets/Scripts/NonRepeatingTextGetter.cs
@@ -1,0 +1,79 @@
+﻿using Constants;
+using System.Collections.Generic;
+using UnityEngine;
+using static Constants.PlayerLabels;
+
+internal class NonRepeatingTextGetter
+{
+    private List<string> unusedGeneralText = new();
+    private List<string> unusedDevReqText = new();
+    private List<string> unusedITReqText = new();
+    private List<string> unusedPMReqText = new();
+    private List<string> unusedHRReqText = new();
+    private List<string> unusedQAReqText = new();
+
+    public string NonReapetingTextByLabel(LabelEnum label)
+    {
+        string res = "";
+
+        switch (label)
+        {
+            case LabelEnum.Dev:
+                if(unusedDevReqText.Count==0)
+                {
+                    unusedDevReqText = new List<string>(Constants.CardText.DevReqText);
+                }
+                res = unusedDevReqText[Random.Range(0, unusedDevReqText.Count)];
+                unusedDevReqText.Remove(res);
+                break;
+            case LabelEnum.IT:
+                if (unusedITReqText.Count == 0)
+                {
+                    unusedITReqText = new List<string>(Constants.CardText.ITReqText);
+                }
+                res = unusedITReqText[Random.Range(0, unusedITReqText.Count)];
+                unusedITReqText.Remove(res);
+                break;
+            case LabelEnum.PM:
+                if (unusedPMReqText.Count == 0)
+                {
+                    unusedPMReqText = new List<string>(Constants.CardText.PMReqText);
+                }
+                res = unusedPMReqText[Random.Range(0, unusedPMReqText.Count)];
+                unusedPMReqText.Remove(res);
+                break;
+            case LabelEnum.HR:
+                if (unusedHRReqText.Count == 0)
+                {
+                    unusedHRReqText = new List<string>(Constants.CardText.HRReqText);
+                }
+                res = unusedHRReqText[Random.Range(0, unusedHRReqText.Count)];
+                unusedHRReqText.Remove(res);
+                break;
+            case LabelEnum.QA:
+                if (unusedQAReqText.Count == 0)
+                {
+                    unusedQAReqText = new List<string>(Constants.CardText.QAReqText);
+                }
+                res = unusedQAReqText[Random.Range(0, unusedQAReqText.Count)];
+                unusedQAReqText.Remove(res);
+                break;
+        }
+
+        return res;
+    }
+
+    public string NonReapetingTextGeneral()
+    {
+        string res = "";
+
+        if (unusedGeneralText.Count == 0)
+        {
+            unusedGeneralText = new List<string>(Constants.CardText.GeneralText);
+        }
+        res = unusedGeneralText[Random.Range(0, unusedGeneralText.Count)];
+        unusedGeneralText.Remove(res);
+
+        return res;
+    }
+}

--- a/Empathy-Game/Assets/Scripts/NonRepeatingTextGetter.cs.meta
+++ b/Empathy-Game/Assets/Scripts/NonRepeatingTextGetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4a5d3419a4d0b5489862f01308e5aa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
א. עוד card texts 
ב. לוגיקה של סיכוי לשלוף קלף אישי\ קלף co op, כרגע היא 50.50 אבל תגידו מה דעתכם ונשנה בהתאם
ג. לוגיקה שמונעת חזרה על טקסט של קלפים, היו 2 דרכים לממש את זה לפי דעתי:
1. כל ראונד לאפס רשימה של כל הטקסטים האפשריים ולקחת מהם
2. כל פעם שנגמרת רשימה של טקסטים לאפס אותה לכל הטקסטים האפשריים

הלכתי על אופציה 2 כי ככה גם בין ראונדים יש פחות חזרה על טקסטים (טקסט שלא קיבלת ראונד קודם תקבל עכשיו), מצד שני יכול להיות איזה ראונד שבו כן נראה את אותם הטקסטים אם זה בדיוק המקום בו שלפנו קלף אחד, ואז נגמרו הקלפים אז הרשימה התאפסה, ואז שלפנו עוד קלף והוא בדיוק יצא הטקסט של הקודם 

תגידו לי איזה מבן הגישות אתם מעדיפים